### PR TITLE
Integrate Pagar.me wallet management

### DIFF
--- a/Bsk.Solution/Bsk.Site/Cliente/meus-cartoes.aspx
+++ b/Bsk.Solution/Bsk.Site/Cliente/meus-cartoes.aspx
@@ -124,42 +124,39 @@
             <div class="grid">
                 <!-- LEFT: list of cards -->
                 <asp:UpdatePanel ID="updLeft" runat="server" UpdateMode="Conditional">
-  <ContentTemplate>
-<div class="panel left">
-    <div class="detail">
-    <div class="detail-head">
-                    <div class="cards">
-                        <asp:ListView ID="lvCartoes" runat="server" DataKeyNames="Id" OnItemCommand="lvCartoes_ItemCommand">
-    <ItemTemplate>
-        <asp:LinkButton runat="server"
-            CommandName="selectCard"
-            CommandArgument='<%# Eval("Id") %>'
-            CssClass='<%# (Eval("Id").ToString() == SelectedId ? "card-row active" : "card-row") %>'>
-            <span class="thumb">nu</span>
-            <span class="meta">
-                <span class="brand"><%# Eval("NomeCartao") %></span>
-                <span class="last4">Cartão final •••• <%# Últimos4(Eval("NumeroCartao")) %></span>
-            </span>
-        </asp:LinkButton>
-    </ItemTemplate>
-</asp:ListView>
-                        <div class="detail">
-                            <div class="detail-head">
+                    <ContentTemplate>
+                        <div class="panel left">
+                            <div class="detail">
+                                <div class="cards">
+                                    <asp:ListView ID="lvCartoes" runat="server" DataKeyNames="Id" OnItemCommand="lvCartoes_ItemCommand">
+                                        <ItemTemplate>
+                                            <asp:LinkButton runat="server"
+                                                CommandName="selectCard"
+                                                CommandArgument='<%# Eval("Id") %>'
+                                                CssClass='<%# (Eval("Id").ToString() == SelectedId ? "card-row active" : "card-row") %>'>
+                                                <span class="thumb">nu</span>
+                                                <span class="meta">
+                                                    <span class="brand"><%# Eval("Brand") %></span>
+                                                    <span class="last4">Cartão final •••• <%# Eval("LastFourDigits") %></span>
+                                                </span>
+                                            </asp:LinkButton>
+                                        </ItemTemplate>
+                                    </asp:ListView>
+                                    <asp:PlaceHolder runat="server" ID="phSemCartoes" Visible="false">
+                                        <div class="card-row">Nenhum cartão cadastrado</div>
+                                    </asp:PlaceHolder>
+                                </div>
                                 <div class="actions">
                                     <asp:Button runat="server" ID="btnNovo" Text="Adicionar cartão" CssClass="btn primary" OnClick="AbrirModoAdicionar" />
                                 </div>
                             </div>
                         </div>
-                    </div>
-            </div>
-</div>
-                </div>
-  </ContentTemplate>
-  <Triggers>
-    <asp:AsyncPostBackTrigger ControlID="btnAdicionar" EventName="Click" />
-    <asp:AsyncPostBackTrigger ControlID="btnRemover" EventName="Click" />
-  </Triggers>
-</asp:UpdatePanel>
+                    </ContentTemplate>
+                    <Triggers>
+                        <asp:AsyncPostBackTrigger ControlID="btnAdicionar" EventName="Click" />
+                        <asp:AsyncPostBackTrigger ControlID="btnRemover" EventName="Click" />
+                    </Triggers>
+                </asp:UpdatePanel>
 
 
                 <!-- RIGHT: selected card details -->
@@ -193,10 +190,6 @@
                             <!-- Add / Edit form (simple add for now) -->
                             <div id="areaAdd" runat="server" visible="false">
                                 <div class="form">
-                                    <div class="field">
-                                        <label>Apelido do cartão</label>
-                                        <input id="nomeCartao" runat="server" type="text" />
-                                    </div>
                                     <div class="field">
                                         <label>Nome do titular</label>
                                         <input id="nomeTItular" runat="server" type="text" />

--- a/Bsk.Solution/Bsk.Site/Cliente/meus-cartoes.aspx.cs
+++ b/Bsk.Solution/Bsk.Site/Cliente/meus-cartoes.aspx.cs
@@ -1,9 +1,8 @@
-﻿using Bsk.BE;
-using Bsk.Interface;
 using Bsk.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 
@@ -11,8 +10,20 @@ namespace Bsk.Site.Cliente
 {
     public partial class meus_cartoes : System.Web.UI.Page
     {
-        core _core = new core();
-        CartaoBE _cartaoBE = new CartaoBE();
+        private readonly PagarMeWalletClient _wallet = new PagarMeWalletClient();
+        private List<PagarMeCard> _cards;
+
+        private string CustomerId
+        {
+            get
+            {
+                var cookie = Request.Cookies["Login"];
+                var login = Funcoes.PegaLoginParticipante(cookie?.Value ?? string.Empty);
+                return login.IdParticipante.ToString();
+            }
+        }
+
+        private List<PagarMeCard> Cards => _cards ?? (_cards = _wallet.ListCards(CustomerId));
 
         protected string SelectedId
         {
@@ -24,6 +35,7 @@ namespace Bsk.Site.Cliente
         {
             if (!IsPostBack)
             {
+                _cards = _wallet.ListCards(CustomerId);
                 BindCartoes();
                 EnsureSelected();
                 BindDetalhe();
@@ -32,8 +44,9 @@ namespace Bsk.Site.Cliente
 
         private void BindCartoes()
         {
-            lvCartoes.DataSource = PegaCartoes();
+            lvCartoes.DataSource = Cards;
             lvCartoes.DataBind();
+            phSemCartoes.Visible = !Cards.Any();
         }
 
         private void EnsureSelected()
@@ -43,35 +56,33 @@ namespace Bsk.Site.Cliente
 
             if (string.IsNullOrEmpty(SelectedId))
             {
-                var first = PegaCartoes().FirstOrDefault();
-                if (first != null) SelectedId = first.Id.ToString();
+                var first = Cards.FirstOrDefault();
+                if (first != null) SelectedId = first.Id;
             }
         }
+        private PagarMeCard GetSelected() => Cards.FirstOrDefault(c => c.Id == SelectedId);
 
         private void BindDetalhe()
         {
             var card = GetSelected();
-            if (card == null) { ClearDetail(); return; }
+            if (card == null)
+            {
+                ClearDetail();
+                return;
+            }
 
-            lblNomeCartao.Text = card.NomeCartao;
-            lblNumeroMascarado.Text = Mascara(card.NumeroCartao);
-            lblTitular.Text = card.NomeTitular;
-            lblExp.Text = $"Expira {card.MesExpiracao:00}/{card.AnoExpiracao}";
+            lblNomeCartao.Text = card.Brand;
+            lblNumeroMascarado.Text = Mascara(card.LastFourDigits);
+            lblTitular.Text = card.HolderName;
+            lblExp.Text = $"Expira {card.ExpMonth:00}/{card.ExpYear}";
+            btnRemover.Visible = true;
         }
 
         private void ClearDetail()
         {
             lblNomeCartao.Text = ""; lblNumeroMascarado.Text = ""; lblTitular.Text = ""; lblExp.Text = "";
+            btnRemover.Visible = false;
         }
-
-        public List<CartaoBE> PegaCartoes()
-        {
-            var login = Funcoes.PegaLoginParticipante(Request.Cookies["Login"].Value);
-            var cartoes = _core.Cartao_Get(_cartaoBE, "IdParticipante= " + login.IdParticipante);
-            return cartoes ?? new List<CartaoBE>();
-        }
-
-        private CartaoBE GetSelected() => PegaCartoes().FirstOrDefault(c => c.Id.ToString() == SelectedId);
 
         protected void lvCartoes_ItemCommand(object sender, ListViewCommandEventArgs e)
         {
@@ -86,10 +97,16 @@ namespace Bsk.Site.Cliente
         protected void btnRemoverSelected_Click(object sender, EventArgs e)
         {
             if (string.IsNullOrEmpty(SelectedId)) return;
-            _cartaoBE.Id = Convert.ToInt32(SelectedId);
-            _core.Cartao_Delete(_cartaoBE);
-            SelectedId = string.Empty;
+            var del = _wallet.DeleteCard(CustomerId, SelectedId);
+            if (!del.Success)
+            {
+                var msg = HttpUtility.JavaScriptStringEncode(del.Error ?? "Erro ao remover cartão.");
+                ScriptManager.RegisterStartupScript(this, GetType(), "swalRemErr", $"Swal.fire({{icon:'error',title:'Erro',text:'{msg}'}});", true);
+                return;
+            }
 
+            SelectedId = string.Empty;
+            _cards = _wallet.ListCards(CustomerId);
             BindCartoes();
             EnsureSelected();
             BindDetalhe();
@@ -100,52 +117,64 @@ namespace Bsk.Site.Cliente
         // Toggle add form
         protected void AbrirModoAdicionar(object sender, EventArgs e)
         {
+            nomeTItular.Value = numeroCartao.Value = mes.Value = ano.Value = codigo.Value = string.Empty;
             areaAdd.Visible = true;
         }
         protected void FecharModoAdicionar(object sender, EventArgs e)
         {
             areaAdd.Visible = false;
+            nomeTItular.Value = numeroCartao.Value = mes.Value = ano.Value = codigo.Value = string.Empty;
         }
 
         protected void btnAdicionar_Click(object sender, EventArgs e)
         {
-            var login = Funcoes.PegaLoginParticipante(Request.Cookies["Login"].Value);
-            var novo = new CartaoBE();
-            novo.IdParticipante = login.IdParticipante;
-            novo.NomeCartao = nomeCartao.Value;
-            novo.NomeTitular = nomeTItular.Value;
-            novo.NumeroCartao = numeroCartao.Value.Replace(" ", "");
-            novo.MesExpiracao = Convert.ToInt32(mes.Value);
-            novo.AnoExpiracao = Convert.ToInt32(ano.Value);
-            novo.CVV = codigo.Value;
+            if (!int.TryParse(mes.Value, out var m) || !int.TryParse(ano.Value, out var a))
+            {
+                areaAdd.Visible = true;
+                ScriptManager.RegisterStartupScript(this, GetType(), "swalVal", "Swal.fire({icon:'error',title:'Dados inválidos',text:'Verifique os campos informados.'});", true);
+                return;
+            }
 
-            _core.Cartao_Insert(novo);
+            var req = new PagarMeCardCreateRequest
+            {
+                HolderName = nomeTItular.Value,
+                Number = numeroCartao.Value.Replace(" ", ""),
+                ExpMonth = m,
+                ExpYear = a,
+                Cvv = codigo.Value
+            };
+
+            var result = _wallet.AddCard(CustomerId, req);
+            if (!result.Success)
+            {
+                areaAdd.Visible = true;
+                var msg = HttpUtility.JavaScriptStringEncode(result.Error ?? "Não foi possível salvar o cartão.");
+                ScriptManager.RegisterStartupScript(this, GetType(), "swalAddErr", $"Swal.fire({{icon:'error',title:'Erro',text:'{msg}'}});", true);
+                return;
+            }
 
             areaAdd.Visible = false;
+            nomeTItular.Value = numeroCartao.Value = mes.Value = ano.Value = codigo.Value = string.Empty;
+
+            _cards = _wallet.ListCards(CustomerId);
+            SelectedId = result.Data?.Id;
             BindCartoes();
             EnsureSelected();
             BindDetalhe();
 
             ScriptManager.RegisterStartupScript(
                 this, GetType(), "swalAdd",
-                "Swal.fire({icon:'success',title:'Adicionado',text:'Cartão salvo com sucesso!'})" +
-                ".then(()=>{  });",
+                "Swal.fire({icon:'success',title:'Adicionado',text:'Cartão salvo com sucesso!'})",
                 true
             );
         }
 
-        // Helpers used in binding
-        public string Últimos4(object numero)
+        private string Mascara(string last4)
         {
-            var n = (numero ?? string.Empty).ToString();
-            if (n.Length <= 4) return n;
-            return n.Substring(n.Length - 4);
-        }
-        private string Mascara(string numero)
-        {
-            if (string.IsNullOrWhiteSpace(numero)) return string.Empty;
-            var last4 = numero.Length >= 4 ? numero.Substring(numero.Length - 4) : numero;
+            if (string.IsNullOrWhiteSpace(last4)) return string.Empty;
             return $"•••• •••• •••• {last4}";
         }
     }
+
 }
+

--- a/Bsk.Solution/Bsk.Site/Cliente/meus-cartoes.aspx.designer.cs
+++ b/Bsk.Solution/Bsk.Site/Cliente/meus-cartoes.aspx.designer.cs
@@ -42,6 +42,15 @@ namespace Bsk.Site.Cliente
         protected global::System.Web.UI.WebControls.ListView lvCartoes;
 
         /// <summary>
+        /// phSemCartoes control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.PlaceHolder phSemCartoes;
+
+        /// <summary>
         /// btnNovo control.
         /// </summary>
         /// <remarks>
@@ -112,15 +121,6 @@ namespace Bsk.Site.Cliente
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl areaAdd;
-
-        /// <summary>
-        /// nomeCartao control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlInputText nomeCartao;
 
         /// <summary>
         /// nomeTItular control.

--- a/Bsk.Solution/Bsk.Site/Web.config
+++ b/Bsk.Solution/Bsk.Site/Web.config
@@ -27,6 +27,7 @@
     <!--<add key="host" value="http://localhost:57642/"/>-->
     <add key="Api" value="http://209.133.199.252:5204/api/"/>
     <!--  <add key="Api" value="https://localhost:5001/api/" />-->
+    <add key="PagarmeApiKey" value=""/>
   </appSettings>
   <!--<connectionStrings>
     <add name="MySQLConnectionString" connectionString="Server=argos-net.nethorizontes.com.br; Port=3306; Database=bsk_brikk; Uid=AreaCompra; Pwd=Brasuka@2014;Connect Timeout=30;"/>

--- a/Bsk.Solution/Bsk.Util/Bsk.Util.csproj
+++ b/Bsk.Solution/Bsk.Util/Bsk.Util.csproj
@@ -111,13 +111,14 @@
       <HintPath>..\packages\ZstdSharp.Port.0.7.1\lib\net461\ZstdSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BskPag.cs" />
-    <Compile Include="Constantes.cs" />
-    <Compile Include="Funcoes.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Sms.cs" />
-  </ItemGroup>
+    <ItemGroup>
+      <Compile Include="BskPag.cs" />
+      <Compile Include="Constantes.cs" />
+      <Compile Include="Funcoes.cs" />
+      <Compile Include="Properties\AssemblyInfo.cs" />
+      <Compile Include="Sms.cs" />
+      <Compile Include="PagarMeWalletClient.cs" />
+    </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />

--- a/Bsk.Solution/Bsk.Util/PagarMeWalletClient.cs
+++ b/Bsk.Solution/Bsk.Util/PagarMeWalletClient.cs
@@ -1,0 +1,118 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Bsk.Util
+{
+    public class PagarMeWalletClient
+    {
+        private readonly HttpClient _http;
+        public PagarMeWalletClient()
+        {
+            var apiKey = ConfigurationManager.AppSettings["PagarmeApiKey"] ?? string.Empty;
+            _http = new HttpClient { BaseAddress = new Uri("https://api.pagar.me/core/v5/") };
+            var auth = Convert.ToBase64String(Encoding.ASCII.GetBytes(apiKey + ":"));
+            _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", auth);
+        }
+
+        public List<PagarMeCard> ListCards(string customerId)
+        {
+            try
+            {
+                var resp = _http.GetAsync($"customers/{customerId}/cards").Result;
+                if (!resp.IsSuccessStatusCode) return new List<PagarMeCard>();
+                var json = resp.Content.ReadAsStringAsync().Result;
+                return JsonConvert.DeserializeObject<List<PagarMeCard>>(json);
+            }
+            catch
+            {
+                return new List<PagarMeCard>();
+            }
+        }
+
+        public PagarMeResult<PagarMeCard> AddCard(string customerId, PagarMeCardCreateRequest req)
+        {
+            try
+            {
+                var json = JsonConvert.SerializeObject(req);
+                var resp = _http.PostAsync($"customers/{customerId}/cards", new StringContent(json, Encoding.UTF8, "application/json")).Result;
+                var respJson = resp.Content.ReadAsStringAsync().Result;
+                if (!resp.IsSuccessStatusCode)
+                {
+                    return new PagarMeResult<PagarMeCard> { Error = ParseError(respJson) ?? resp.StatusCode.ToString() };
+                }
+                var card = JsonConvert.DeserializeObject<PagarMeCard>(respJson);
+                return new PagarMeResult<PagarMeCard> { Data = card };
+            }
+            catch (Exception ex)
+            {
+                return new PagarMeResult<PagarMeCard> { Error = ex.Message };
+            }
+        }
+
+        public PagarMeResult<bool> DeleteCard(string customerId, string cardId)
+        {
+            try
+            {
+                var resp = _http.DeleteAsync($"customers/{customerId}/cards/{cardId}").Result;
+                var body = resp.Content.ReadAsStringAsync().Result;
+                if (!resp.IsSuccessStatusCode)
+                {
+                    return new PagarMeResult<bool> { Error = ParseError(body) ?? resp.StatusCode.ToString() };
+                }
+                return new PagarMeResult<bool> { Data = true };
+            }
+            catch (Exception ex)
+            {
+                return new PagarMeResult<bool> { Error = ex.Message };
+            }
+        }
+
+        private string ParseError(string json)
+        {
+            try
+            {
+                var token = JToken.Parse(json);
+                var msg = token.SelectToken("errors[0].message") ?? token.SelectToken("message");
+                return msg?.ToString();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    public class PagarMeCard
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("holder_name")] public string HolderName { get; set; }
+        [JsonProperty("last_four_digits")] public string LastFourDigits { get; set; }
+        [JsonProperty("brand")] public string Brand { get; set; }
+        [JsonProperty("exp_month")] public int ExpMonth { get; set; }
+        [JsonProperty("exp_year")] public int ExpYear { get; set; }
+        [JsonProperty("status")] public string Status { get; set; }
+    }
+
+    public class PagarMeCardCreateRequest
+    {
+        [JsonProperty("holder_name")] public string HolderName { get; set; }
+        [JsonProperty("number")] public string Number { get; set; }
+        [JsonProperty("exp_month")] public int ExpMonth { get; set; }
+        [JsonProperty("exp_year")] public int ExpYear { get; set; }
+        [JsonProperty("cvv")] public string Cvv { get; set; }
+        [JsonProperty("holder_document")] public string HolderDocument { get; set; }
+    }
+
+    public class PagarMeResult<T>
+    {
+        public T Data { get; set; }
+        public string Error { get; set; }
+        public bool Success => Error == null;
+    }
+}


### PR DESCRIPTION
## Summary
- Link card management page to Pagar.me wallet API
- Allow adding, listing and removing cards using Pagar.me
- Expose Pagar.me API key in configuration
- Extract wallet client into reusable utility and cache card list
- Refine card page UI and behavior for empty wallets and newly added cards
- Handle API errors and validation to keep Add Card button responsive

## Testing
- `msbuild Bsk.Solution/Bsk.Solution.sln` *(fails: command not found)*
- `dotnet build Bsk.Solution/Bsk.Solution.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bec694db148329b63e1bc99a93331d