### PR TITLE
Ensure Pagar.me wallet creation for customers

### DIFF
--- a/Bsk.Solution/Bsk.Util/PagarMeWalletClient.cs
+++ b/Bsk.Solution/Bsk.Util/PagarMeWalletClient.cs
@@ -21,6 +21,25 @@ namespace Bsk.Util
             _logger = logger ?? Console.WriteLine;
         }
 
+        public bool EnsureCustomer(string customerId, string name, string email)
+        {
+            try
+            {
+                var payload = new { name = name, email = email };
+                var json = JsonConvert.SerializeObject(payload);
+                var resp = _http.PutAsync($"customers/{customerId}",
+                    new StringContent(json, Encoding.UTF8, "application/json")).Result;
+                var body = resp.Content.ReadAsStringAsync().Result;
+                _logger?.Invoke($"EnsureCustomer response: {(int)resp.StatusCode} - {body}");
+                return resp.IsSuccessStatusCode;
+            }
+            catch (Exception ex)
+            {
+                _logger?.Invoke($"EnsureCustomer error: {ex.Message}");
+                return false;
+            }
+        }
+
         public List<PagarMeCard> ListCards(string customerId)
         {
             try


### PR DESCRIPTION
## Summary
- add `EnsureCustomer` helper in PagarMeWalletClient to upsert Pagar.me customers
- call `EnsureCustomer` when loading or adding cards on the `meus-cartoes` page

## Testing
- `dotnet test Bsk.Solution/Bsk.Solution.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68bfafc55c28832985e4dec21a3f4318