### PR TITLE
Persist selected services when creating solicitacao

### DIFF
--- a/Bsk.Solution/Bsk.BE/SolicitacaoBE.cs
+++ b/Bsk.Solution/Bsk.BE/SolicitacaoBE.cs
@@ -11,6 +11,7 @@ namespace Bsk.BE
         public int IdSolicitacao { get; set; }
         public int IdParticipante { get; set; }
         public int IdCategoria { get; set; }
+        public string IdServico { get; set; }
         public string Status { get; set; }
         public string DataCriacao { get; set; }
         public string DataTermino { get; set; }

--- a/Bsk.Solution/Bsk.Site/Cliente/cadastro-solicitacao.aspx
+++ b/Bsk.Solution/Bsk.Site/Cliente/cadastro-solicitacao.aspx
@@ -47,7 +47,20 @@
          
              </div>
          </div>
-        <asp:Literal ID="litCategoria" runat="server" />
+        <div class="item_content_card">
+            <h2 class="subtitulo_card_1 subtitulo_1">Categoria selecionada</h2>
+            <p class="resumo-categoria">
+                <asp:Literal ID="litCategoria" runat="server" />
+            </p>
+        </div>
+
+        <div class="item_content_card" id="servicosSelecionadosContainer" runat="server">
+            <h2 class="subtitulo_card_1 subtitulo_1">Serviços selecionados</h2>
+            <ul class="lista-servicos">
+                <asp:Literal ID="litServicos" runat="server" />
+            </ul>
+        </div>
+
             <div class="item_content_card">
                 <h2 class="subtitulo_card_1 subtitulo_1">Descrição </h2>
                 <input type="text" placeholder="Digite aqui uma descrição para o serviço a ser realizado" class="card-input-add" id="titulo" runat="server">

--- a/Bsk.Solution/Bsk.Site/Cliente/cadastro-solicitacao.aspx.designer.cs
+++ b/Bsk.Solution/Bsk.Site/Cliente/cadastro-solicitacao.aspx.designer.cs
@@ -24,6 +24,24 @@ namespace Bsk.Site.Cliente
         protected global::System.Web.UI.WebControls.Literal litCategoria;
 
         /// <summary>
+        /// servicosSelecionadosContainer control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl servicosSelecionadosContainer;
+
+        /// <summary>
+        /// litServicos control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Literal litServicos;
+
+        /// <summary>
         /// titulo control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Summary
- add an IdServico field to SolicitacaoBE so solicitacoes can store selected service ids
- preserve the chosen category and services on buscar-servico and include them in the cadastro-solicitacao navigation
- show the chosen services on cadastro-solicitacao and persist the sanitized ids when a new solicitacao is created

## Testing
- dotnet build Bsk.Solution/Bsk.Solution.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9ac57a1988329988ba85de49c5412