### PR TITLE
Add missing assembly references to Web.config compilation settings

### DIFF
--- a/Bsk.Solution/Bsk.Site/Web.config
+++ b/Bsk.Solution/Bsk.Site/Web.config
@@ -51,7 +51,15 @@
     <customErrors mode="Off"/>
     <!--<globalization culture="en-US" uiCulture="en-US" />-->
     <globalization culture="pt-BR" uiCulture="pt-BR"/>
-    <compilation targetFramework="4.8" debug="true"/>
+    <compilation targetFramework="4.8" debug="true">
+      <assemblies>
+        <add assembly="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add assembly="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add assembly="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add assembly="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+        <add assembly="System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+      </assemblies>
+    </compilation>
     <httpRuntime targetFramework="4.5.2" requestValidationMode="2.0" maxRequestLength="1048576"/>
     <pages enableEventValidation="false">
       <namespaces>


### PR DESCRIPTION
## Summary
- add explicit assembly references for ASP.NET MVC and other dependencies to the Web.config compilation section so generated files compile cleanly

## Testing
- `msbuild Bsk.Solution/Bsk.Solution.sln /t:Rebuild` *(fails: `msbuild` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9b7aa2d908329ad35ec1ca2c221dc