### PR TITLE
Fix parsing variable declarations in cadastro solicitacao

### DIFF
--- a/Bsk.Solution/Bsk.Site/Cliente/cadastro-solicitacao.aspx.cs
+++ b/Bsk.Solution/Bsk.Site/Cliente/cadastro-solicitacao.aspx.cs
@@ -212,7 +212,8 @@ namespace Bsk.Site.Cliente
 
         private void BindCategoriaFromQuery()
         {
-            if (int.TryParse(Request.QueryString["Id"], out var categoriaId))
+            int categoriaId;
+            if (int.TryParse(Request.QueryString["Id"], out categoriaId))
             {
                 BindCategoria(categoriaId);
             }
@@ -269,7 +270,8 @@ namespace Bsk.Site.Cliente
             foreach (var part in parts)
             {
                 var trimmed = part.Trim();
-                if (int.TryParse(trimmed, out var parsed) && !ids.Contains(parsed))
+                int parsed;
+                if (int.TryParse(trimmed, out parsed) && !ids.Contains(parsed))
                 {
                     ids.Add(parsed);
                 }


### PR DESCRIPTION
## Summary
- declare categoriaId before TryParse in BindCategoriaFromQuery and use the parsed variable inside the block
- declare parsed before TryParse in ParseServiceIds to avoid inline out variable usage

## Testing
- dotnet build Bsk.Solution/Bsk.Solution.sln *(fails: command not found)*
- msbuild Bsk.Solution/Bsk.Solution.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c9b9a29448832988766c2b5b146e70